### PR TITLE
config: supress_ddl splitted to supress_schema and supress_indexes

### DIFF
--- a/mysql2pgsql/lib/config.py
+++ b/mysql2pgsql/lib/config.py
@@ -69,8 +69,11 @@ destination:
 # if supress_data is true, only the schema definition will be exported/migrated, and not the data
 supress_data: false
 
-# if supress_ddl is true, only the data will be exported/imported, and not the schema
-supress_ddl: false
+# if supress_schema is true, table creation will be skipped
+supress_schema: false
+
+# if supress_indexes is true, index and constraint creation will be skipped
+supress_indexes: false
 
 # if force_truncate is true, forces a table truncate before table loading
 force_truncate: false

--- a/mysql2pgsql/lib/converter.py
+++ b/mysql2pgsql/lib/converter.py
@@ -11,7 +11,8 @@ class Converter(object):
         self.file_options = file_options
         self.exclude_tables = file_options.get('exclude_tables', [])
         self.only_tables = file_options.get('only_tables', [])
-        self.supress_ddl = file_options.get('supress_ddl', None)
+        self.supress_schema = file_options.get('supress_schema', None)
+        self.supress_indexes = file_options.get('supress_indexes', None)
         self.supress_data = file_options.get('supress_data', None)
         self.force_truncate = file_options.get('force_truncate', None)
 
@@ -23,7 +24,7 @@ class Converter(object):
         if self.only_tables:
             tables.sort(key=lambda t: self.only_tables.index(t.name))
         
-        if not self.supress_ddl:
+        if not self.supress_schema:
             if self.verbose:
                 print_start_table('START CREATING TABLES')
 
@@ -33,7 +34,7 @@ class Converter(object):
             if self.verbose:
                 print_start_table('DONE CREATING TABLES')
 
-        if self.force_truncate and self.supress_ddl:
+        if self.force_truncate and self.supress_schema:
             if self.verbose:
                 print_start_table('START TRUNCATING TABLES')
 
@@ -53,7 +54,7 @@ class Converter(object):
             if self.verbose:
                 print_start_table('DONE WRITING TABLE DATA')
 
-        if not self.supress_ddl:
+        if not self.supress_indexes:
             if self.verbose:
                 print_start_table('START CREATING INDEXES AND CONSTRAINTS')
 

--- a/mysql2pgsql/lib/postgres_writer.py
+++ b/mysql2pgsql/lib/postgres_writer.py
@@ -228,6 +228,10 @@ class PostgresWriter(object):
         index_sql = []
         primary_index = [idx for idx in table.indexes if idx.get('primary', None)]
         if primary_index:
+            index_sql.append('ALTER TABLE "%(table_name)s" DROP CONSTRAINT IF EXISTS "%(index_name)s_pkey";' % {
+                    'table_name': table.name,
+                    'index_name': '%s_%s' % (table.name, '_'.join(primary_index[0]['columns']))
+                    })
             index_sql.append('ALTER TABLE "%(table_name)s" ADD CONSTRAINT "%(index_name)s_pkey" PRIMARY KEY(%(column_names)s);' % {
                     'table_name': table.name,
                     'index_name': '%s_%s' % (table.name, '_'.join(primary_index[0]['columns'])),


### PR DESCRIPTION
The main reason for this patch is to provide a way to create indexes after data transfer, which highly speeds up data insertion.
For example, on 100GB database it was about 24 hours to insert all data to indexed tables, and roughly 4+2 hours for data transfer and index creation separated (using two invocations of mysql2pgsql with different configs)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/philipsoutham/py-mysql2pgsql/48)

<!-- Reviewable:end -->
