### PR TITLE
Set index_prefix to '' in CONFIG_TEMPLATE.

### DIFF
--- a/mysql2pgsql/lib/config.py
+++ b/mysql2pgsql/lib/config.py
@@ -82,6 +82,6 @@ force_truncate: false
 timezone: false
 
 # if index_prefix is given, indexes will be created whith a name prefixed with index_prefix
-index_prefix:
+index_prefix: ''
 
 """


### PR DESCRIPTION
With the example generated configuration leaving in the index_prefix option will generate 'None' as a prefix. Easiest solution is to just set it to an empty string, otherwise we would need to test for a None value in the code.
