### PR TITLE
Fixed parsing of b'1', and ^A and ^@ for boolean values.

### DIFF
--- a/mysql2pgsql/lib/postgres_writer.py
+++ b/mysql2pgsql/lib/postgres_writer.py
@@ -59,7 +59,7 @@ class PostgresWriter(object):
                 default = (" DEFAULT %s" % (column['default'] if t(column['default']) else 'NULL')) if t(default) else None
                 return default, 'smallint'
             elif column['type'] == 'boolean':
-                default = (" DEFAULT %s" % ('true' if int(column['default']) == 1 else 'false')) if t(default) else None
+                default = (" DEFAULT %s" % ('true' if '1' in column['default'] else 'false')) if t(default) else None
                 return default, 'boolean'
             elif column['type'] == 'float':
                 default = (" DEFAULT %s" % (column['default'] if t(column['default']) else 'NULL')) if t(default) else None
@@ -149,7 +149,9 @@ class PostgresWriter(object):
             elif 'bit' in column_type:
                 row[index] = bin(ord(row[index]))[2:]
             elif isinstance(row[index], (str, unicode, basestring)):
-                if column_type == 'bytea':
+                if column_type == 'boolean':
+                    row[index] = 't' if row[index] == '\x01' else 'f' if row[index] == '\x00' or row[index] == '' else row[index]
+                elif column_type == 'bytea':
                     row[index] = Binary(row[index]).getquoted()[1:-8] if row[index] else row[index]
                 elif 'text[' in column_type:
                     row[index] = '{%s}' % ','.join('"%s"' % v.replace('"', r'\"') for v in row[index].split(','))


### PR DESCRIPTION
```
b'1' occurs in the dafault value for bit(1) fields.

(Latter was really done by https://github.com/cewing.)

MariaDB [test]> show create table bintest\G
*************************** 1. row ***************************
       Table: bintest
Create Table: CREATE TABLE `bintest` (
  `b` bit(1) DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=latin1
1 row in set (0.00 sec)

MariaDB [test]> select * from bintest;
+------+
| b    |
+------+
|      |  -- zero, meaning false, prints as only spaces
|     | -- one, meaning true, prints as a single \x01
| NULL |  -- when the row is NULL
+------+
3 rows in set (0.00 sec)
```
