### PR TITLE
Allows access to local Postgres server without password

### DIFF
--- a/mysql2pgsql/lib/postgres_db_writer.py
+++ b/mysql2pgsql/lib/postgres_db_writer.py
@@ -72,12 +72,14 @@ class PostgresDbWriter(PostgresWriter):
         super(PostgresDbWriter, self).__init__(*args, **kwargs)
         self.verbose = verbose
         self.db_options = {
-            'host': str(db_options['hostname']),
-            'port': db_options.get('port', 5432),
             'database': str(db_options['database']),
-            'password': str(db_options.get('password', None)) or '',
+            'password': str(db_options.get('password', None) or ''),
             'user': str(db_options['username']),
             }
+        if db_options.get('hostname'):
+            self.db_options['host'] = db_options.get('hostname')
+            self.db_options['port'] = db_options.get('port', 5432)
+
         if ':' in str(db_options['database']):
             self.db_options['database'], self.schema = self.db_options['database'].split(':')
         else:


### PR DESCRIPTION
This change allows the user to leave hostname empty to connect to a local server with no password. Also fixes an error in parsing empty passwords (that would become 'None' as string).