### PR TITLE
Match varbinary(...) column types

### DIFF
--- a/mysql2pgsql/lib/postgres_writer.py
+++ b/mysql2pgsql/lib/postgres_writer.py
@@ -104,7 +104,7 @@ class PostgresWriter(object):
                     return default, 'time with time zone'
                 else:
                     return default, 'time without time zone'
-            elif column['type'] in ('blob', 'binary', 'longblob', 'mediumblob', 'tinyblob', 'varbinary'):
+            elif column['type'] in ('blob', 'binary', 'longblob', 'mediumblob', 'tinyblob') or column['type'].startswith('varbinary'):
                 return default, 'bytea'
             elif column['type'] in ('tinytext', 'mediumtext', 'longtext', 'text'):
                 return default, 'text'


### PR DESCRIPTION
`varbinary` can have a parameter such as `varbinary(16)`. This change allows such types to be recognized.
