### PR TITLE
can't execute an empty query #Fixed

### DIFF
--- a/mysql2pgsql/lib/postgres_db_writer.py
+++ b/mysql2pgsql/lib/postgres_db_writer.py
@@ -151,7 +151,8 @@ class PostgresDbWriter(PostgresWriter):
         """
         table_sql, serial_key_sql = super(PostgresDbWriter, self).write_table(table)
         for sql in serial_key_sql + table_sql:
-            self.execute(sql)
+            if sql != "":
+                self.execute(sql)
 
     @status_logger
     def write_indexes(self, table):


### PR DESCRIPTION
psycopg2.ProgrammingError: can't execute an empty query